### PR TITLE
Add tests for EspoCRM integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,7 @@ The MCP Unified Server provides a unified interface for Claude to interact with 
 - **Excel**: Create and manipulate Excel spreadsheets
 - **Yahoo Finance**: Stock market and financial data
 - **FRED**: Federal Reserve Economic Data
+- **EspoCRM**: Manage CRM contacts and other records
 - **Agentic capabilities**: Create and deploy autonomous agents that perform complex tasks
 - **And many more specialized tools**
 
@@ -86,6 +87,7 @@ Option 1 - Using docker-compose:
 ```
 docker-compose up
 ```
+This will start the MCP server as well as an EspoCRM instance.
 Option 2 - Direct Docker command:
 ```
 docker run -p 8000:8000 -v ~/documents:/app/documents getfounded/mcp-tool-kit:latest
@@ -197,6 +199,8 @@ Alternatively, you can manually create a `.env` file in the repository root with
 BRAVE_API_KEY=your_brave_api_key
 NEWS_API_KEY=your_news_api_key
 FRED_API_KEY=your_fred_api_key
+ESPOCRM_BASE_URL=http://localhost:8040
+ESPOCRM_API_KEY=your_espocrm_api_key
 
 # Application configuration
 STREAMLIT_APPS_DIR=/path/to/streamlit/apps
@@ -265,6 +269,9 @@ Once set up, you can ask Claude to use the tools with prompts like:
   - `fred_get_category`: Browse data by category
   - `fred_get_releases`: Get economic data releases
   - `fred_get_sources`: Get data sources
+
+### EspoCRM
+- `espocrm_get_contacts`: Retrieve contacts from your EspoCRM instance
 
 ### Time Tools
 - `get_current_time`: Get current time in a specified timezone

--- a/app/tools/espocrm.py
+++ b/app/tools/espocrm.py
@@ -1,0 +1,99 @@
+#!/usr/bin/env python3
+"""EspoCRM tool module for MCP Tool Kit."""
+
+import os
+import json
+import logging
+
+from mcp.server.fastmcp import Context
+
+import httpx
+
+external_mcp = None
+
+
+def set_external_mcp(mcp):
+    """Set the external MCP reference for tool registration"""
+    global external_mcp
+    external_mcp = mcp
+    logging.info("EspoCRM tools MCP reference set")
+
+
+class EspoCRMService:
+    """Simple service wrapper around the EspoCRM REST API."""
+
+    def __init__(self, base_url: str, api_key: str):
+        self.base_url = base_url.rstrip('/')
+        self.api_key = api_key
+
+    async def get_contacts(self, limit: int = 20):
+        """Retrieve a list of contacts."""
+        url = f"{self.base_url}/api/v1/Contact"
+        headers = {"Authorization": f"Bearer {self.api_key}"}
+        params = {"maxSize": limit}
+        async with httpx.AsyncClient() as client:
+            response = await client.get(url, headers=headers, params=params)
+            response.raise_for_status()
+            return response.json()
+
+
+_espocrm_service: EspoCRMService | None = None
+
+
+def initialize_espocrm_service(base_url: str | None = None, api_key: str | None = None):
+    """Initialize the EspoCRM service."""
+    global _espocrm_service
+    if base_url is None:
+        base_url = os.environ.get("ESPOCRM_BASE_URL")
+    if api_key is None:
+        api_key = os.environ.get("ESPOCRM_API_KEY")
+
+    if not base_url or not api_key:
+        logging.warning(
+            "EspoCRM credentials not configured. Set ESPOCRM_BASE_URL and ESPOCRM_API_KEY.")
+        return None
+
+    _espocrm_service = EspoCRMService(base_url, api_key)
+    return _espocrm_service
+
+
+def _get_espocrm_service() -> EspoCRMService | None:
+    global _espocrm_service
+    if _espocrm_service is None:
+        _espocrm_service = initialize_espocrm_service()
+    return _espocrm_service
+
+
+async def espocrm_get_contacts(limit: int = 20, ctx: Context | None = None) -> str:
+    """Get a list of contacts from EspoCRM."""
+    service = _get_espocrm_service()
+    if not service:
+        return (
+            "EspoCRM is not configured. Please set ESPOCRM_BASE_URL and ESPOCRM_API_KEY."
+        )
+    try:
+        result = await service.get_contacts(limit)
+        return json.dumps(result, indent=2)
+    except Exception as e:
+        return f"Error retrieving contacts: {e}"
+
+
+def get_espocrm_tools():
+    """Return EspoCRM tools for MCP registration."""
+    return {
+        "espocrm_get_contacts": espocrm_get_contacts,
+    }
+
+
+def initialize(mcp=None):
+    """Initialize the EspoCRM module."""
+    if mcp:
+        set_external_mcp(mcp)
+
+    service = initialize_espocrm_service()
+    if service:
+        logging.info("EspoCRM service initialized successfully")
+    else:
+        logging.warning("Failed to initialize EspoCRM service")
+
+    return service is not None

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,6 +10,8 @@ services:
       - BROWSERBASE_API_KEY=${BROWSERBASE_API_KEY}
       - BROWSERBASE_PROJECT_ID=${BROWSERBASE_PROJECT_ID}
       - NEWS_API_KEY=${NEWS_API_KEY}
+      - ESPOCRM_BASE_URL=http://espocrm
+      - ESPOCRM_API_KEY=${ESPOCRM_API_KEY}
       - PYTHONUNBUFFERED=1  # Ensures python output isn't buffered
       - MCP_HOST=0.0.0.0  # Host binding for MCP server
       - MCP_PORT=8000     # Port for MCP server
@@ -21,4 +23,33 @@ services:
       interval: 30s
       timeout: 10s
       retries: 3
-      start_period: 5s  
+      start_period: 5s
+
+  espocrm-db:
+    image: mariadb:10.5
+    environment:
+      - MYSQL_ROOT_PASSWORD=espocrm
+      - MYSQL_DATABASE=espocrm
+      - MYSQL_USER=espocrm
+      - MYSQL_PASSWORD=espocrm
+    volumes:
+      - espocrm_db:/var/lib/mysql
+
+  espocrm:
+    image: espocrm/espocrm:latest
+    depends_on:
+      - espocrm-db
+    environment:
+      - ESPOCRM_DATABASE_HOST=espocrm-db
+      - ESPOCRM_DATABASE_USER=espocrm
+      - ESPOCRM_DATABASE_PASSWORD=espocrm
+      - ESPOCRM_DATABASE_NAME=espocrm
+    ports:
+      - "8040:80"
+    volumes:
+      - espocrm_data:/var/www/html
+    restart: unless-stopped
+
+volumes:
+  espocrm_db:
+  espocrm_data:

--- a/mcp_unified_server.py
+++ b/mcp_unified_server.py
@@ -457,6 +457,33 @@ try:
 except ImportError as e:
     logging.warning(f"Could not load Leave Management tools: {e}")
 
+# Initialize EspoCRM tools
+try:
+    from app.tools.espocrm import (
+        get_espocrm_tools,
+        set_external_mcp as set_espocrm_mcp,
+        initialize_espocrm_service,
+    )
+
+    set_espocrm_mcp(mcp)
+
+    base_url = os.environ.get("ESPOCRM_BASE_URL")
+    api_key = os.environ.get("ESPOCRM_API_KEY")
+    if base_url and api_key:
+        initialize_espocrm_service(base_url, api_key)
+
+        espocrm_tools = get_espocrm_tools()
+        for tool_name, tool_func in espocrm_tools.items():
+            mcp.tool(name=tool_name)(tool_func)
+
+        logging.info("EspoCRM tools registered successfully.")
+    else:
+        logging.warning(
+            "EspoCRM credentials not configured. EspoCRM tools will not be available."
+        )
+except ImportError as e:
+    logging.warning(f"Could not load EspoCRM tools: {e}")
+
 
 # Validate required environment variables
 REQUIRED_ENV_VARS = {
@@ -467,6 +494,8 @@ REQUIRED_ENV_VARS = {
     "MCP_FILESYSTEM_DIRS": "/path/to/allowed/dir1,/path/to/allowed/dir2",
     "MCP_LOG_LEVEL": "info",
     "VAPID_API_KEY": "your_vapid_api_key",
+    "ESPOCRM_BASE_URL": "http://espocrm",
+    "ESPOCRM_API_KEY": "your_espocrm_api_key",
 }
 
 missing_vars = [var for var in REQUIRED_ENV_VARS if not os.environ.get(var)]

--- a/setup_env.py
+++ b/setup_env.py
@@ -65,6 +65,18 @@ def main():
             "example": "YOUR_FRED_API_KEY",
             "url": "https://fred.stlouisfed.org/docs/api/api_key.html"
         },
+        "ESPOCRM_BASE_URL": {
+            "description": "Base URL for EspoCRM instance",
+            "required": False,
+            "default": existing_vars.get("ESPOCRM_BASE_URL", "http://localhost:8040"),
+            "example": "http://localhost:8040",
+        },
+        "ESPOCRM_API_KEY": {
+            "description": "API key for EspoCRM REST API",
+            "required": False,
+            "default": existing_vars.get("ESPOCRM_API_KEY", ""),
+            "example": "YOUR_ESPOCRM_API_KEY",
+        },
         "STREAMLIT_APPS_DIR": {
             "description": "Directory for Streamlit applications",
             "required": False,

--- a/tests/test_docker_compose.py
+++ b/tests/test_docker_compose.py
@@ -1,0 +1,40 @@
+import subprocess
+import shutil
+import unittest
+
+import yaml
+
+
+def load_compose():
+    with open('docker-compose.yml') as f:
+        return yaml.safe_load(f)
+
+
+class DockerComposeTest(unittest.TestCase):
+    def test_services_present(self):
+        data = load_compose()
+        services = data.get('services', {})
+        self.assertIn('mcp-server', services)
+        self.assertIn('espocrm', services)
+        self.assertIn('espocrm-db', services)
+        volumes = data.get('volumes', {})
+        self.assertIn('espocrm_db', volumes)
+        self.assertIn('espocrm_data', volumes)
+
+    def test_compose_config_valid(self):
+        docker = shutil.which('docker')
+        if not docker:
+            self.skipTest('Docker not available')
+        try:
+            subprocess.run(
+                [docker, 'compose', '-f', 'docker-compose.yml', 'config'],
+                check=True,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+            )
+        except subprocess.CalledProcessError as e:
+            self.fail(f'Docker compose config failed: {e.stderr.decode()}')
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/test_espocrm.py
+++ b/tests/test_espocrm.py
@@ -1,0 +1,36 @@
+import asyncio
+import json
+import os
+import unittest
+from unittest.mock import patch
+
+import httpx
+
+from app.tools import espocrm
+
+
+class EspoCRMToolTest(unittest.IsolatedAsyncioTestCase):
+    async def asyncSetUp(self):
+        os.environ['ESPOCRM_BASE_URL'] = 'http://testserver'
+        os.environ['ESPOCRM_API_KEY'] = 'dummy'
+        espocrm._espocrm_service = espocrm.EspoCRMService('http://testserver', 'dummy')
+
+    async def test_get_contacts(self):
+        expected = {"list": [{"name": "John Doe"}]}
+
+        async def handler(request: httpx.Request) -> httpx.Response:
+            return httpx.Response(200, json=expected)
+
+        transport = httpx.MockTransport(handler)
+
+        class PatchedAsyncClient(httpx.AsyncClient):
+            def __init__(self, *args, **kwargs):
+                super().__init__(transport=transport)
+
+        with patch('app.tools.espocrm.httpx.AsyncClient', PatchedAsyncClient):
+            result = await espocrm.espocrm_get_contacts(limit=1)
+            self.assertEqual(json.loads(result), expected)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Summary
- add unittest for docker-compose configuration
- add test for EspoCRM contact retrieval tool

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `python -m unittest discover -v`


------
https://chatgpt.com/codex/tasks/task_e_685c168384cc832496fe448f1a3488fa